### PR TITLE
fix(i18n): 修改记录路径的配置键名

### DIFF
--- a/cli/i18n/tran.go
+++ b/cli/i18n/tran.go
@@ -311,8 +311,8 @@ func mergeTranCmdFlags(cmd *cobra.Command) {
 		state.Config.I18n.AutoTran.EnableRecord = utils.GetBool("auto-tran-enable-record", cmd)
 	}
 
-	if cmd.Flag("record-path").Changed {
-		state.Config.I18n.AutoTran.RecordPath = utils.GetString("record-path", cmd)
+	if cmd.Flag("auto-tran-record-path").Changed {
+		state.Config.I18n.AutoTran.RecordPath = utils.GetString("auto-tran-record-path", cmd)
 	}
 
 }

--- a/i18n/tran.go
+++ b/i18n/tran.go
@@ -214,8 +214,11 @@ func translate(parent string, srcLocalize map[string]any, dstLang *Language, dst
 				return true
 			}
 
-			if ok, err := tx.Check(dstLang.Lang, k, dstLocalize[k]); err != nil || !ok {
-				return true
+			if tx != nil {
+				ok, err := tx.Check(dstLang.Lang, k, dstLocalize[k])
+				if err == nil && !ok {
+					return true
+				}
 			}
 
 			return false


### PR DESCRIPTION
-将配置键名从 "record-path" 修改为 "auto-tran-record-path"
- 这样可以避免潜在的冲突，并提高代码的可读性和维护性